### PR TITLE
Added compatibility for Modular Turrets.

### DIFF
--- a/prototypes/functions/compatibility.lua
+++ b/prototypes/functions/compatibility.lua
@@ -332,6 +332,14 @@ if mods["Rocket-Silo-Construction"] then
     end
 end
 
+if mods["scattergun_turret"] then
+    for _, recipe in pairs(data.raw.recipe) do
+        -- tried testing for subcategory, but it's nil at this point
+        if recipe.name:find("^w93-") ~= nil and recipe.name:find("turret2$") ~= nil then
+            recipe.ignore_for_dependencies = true
+        end
+    end
+end
 
 if data.raw.recipe["electronic-circuit"].enabled == false
     and (not data.raw.recipe["electronic-circuit-initial"] or data.raw.recipe["electronic-circuit-initial"].enabled == false)


### PR DESCRIPTION
It has a bunch of techs that add different types of turrets. These techs also give you a 'backline' version of these turrets, but you only get the ability to make those after chem science.

Splitting up the techs seems like a) too much work and b) inflates the tech costs for them, so I opted to ignore those backline recipes for autotech instead.

I've tested this both with and without Modular Turrets enabled, so I don't think this will break anything :)

resolves pyanodon/pybugreports#90