### PR TITLE
Added compatibility for Pushbutton.

### DIFF
--- a/prototypes/functions/compatibility.lua
+++ b/prototypes/functions/compatibility.lua
@@ -333,6 +333,10 @@ if mods["Rocket-Silo-Construction"] then
 end
 
 
+if mods["pushbutton"] then
+    RECIPE("pushbutton"):remove_ingredient("advanced-circuit")
+end
+
 if data.raw.recipe["electronic-circuit"].enabled == false
     and (not data.raw.recipe["electronic-circuit-initial"] or data.raw.recipe["electronic-circuit-initial"].enabled == false)
     and data.raw.recipe["inductor1-2"]


### PR DESCRIPTION
The mod adds pushbutton to the circuit networks tech, requiring red circuits. However, you need circuit networks for Yaedols and Water invertrebrates, which are in turn needed for red circuits, thus causing a dependency loop.

Solved by removing the red circuit ingredient.

Tested with and without pushbutton installed.

resolves pyanodon/pybugreports#140