### PR TITLE
Added compatibility for the Teleporters mod by Klonan for PyAE.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Version: 0.2.5
 Date: 2023-2-??
   Features:
     - Added a command, /check-technology-consistency, to fix techs if the player breaks them by adding/removing mods
+  Changes:
+    - Added compatibility with the Teleporters mod.
 ---------------------------------------------------------------------------------------------------
 Version: 0.2.4
 Date: 2023-1-31

--- a/prototypes/functions/compatibility.lua
+++ b/prototypes/functions/compatibility.lua
@@ -372,6 +372,10 @@ if mods['nixie-tubes'] then
     TECHNOLOGY('cathodes'):remove_pack('logistic-science-pack'):remove_prereq('advanced-electronics')
 end
 
+if mods['Teleporters'] and mods['pyalternativeenergy'] then
+    TECHNOLOGY('teleporter'):remove_prereq('battery'):add_prereq('battery-mk01')
+end
+
 if mods['pushbutton'] then
     RECIPE('pushbutton'):remove_ingredient('advanced-circuit')
 end


### PR DESCRIPTION
The problem is that PyAE disables the 'battery' tech, which Teleporters uses as a prereq. It introduces 'battery-mk01' etc, so I made it depend on that instead.

Tested it with and without PyAE enabled. The battery tech in PyAL is gated by py2, while battery-mk01 is gated by py1, so that's a bit awkward, but I guess it's fine. Otherwise we'd have to change the recipe too etc.