### PR TITLE
Improve T.U.R.D. support in YAFC

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -264,15 +264,6 @@ if mods["pyalternativeenergy"] then
 
 end
 
-
-----------------------------------------------------
--- THIRD PARTY COMPATIBILITY
-----------------------------------------------------
-require('prototypes/functions/compatibility')
-if type(data.data_crawler) == 'string' and string.sub(data.data_crawler, 1, 5) == 'yafc ' then
-    require('prototypes/yafc')
-end
-
 ----------------------------------------------------
 -- TECHNOLOGY CHANGES
 ----------------------------------------------------
@@ -330,4 +321,12 @@ if mods['pycoalprocessing'] then
             subgroup.order = 'b'
         end
     end
+end
+
+----------------------------------------------------
+-- THIRD PARTY COMPATIBILITY
+----------------------------------------------------
+require('prototypes/functions/compatibility')
+if type(data.data_crawler) == 'string' and string.sub(data.data_crawler, 1, 5) == 'yafc ' then
+    require('prototypes/yafc')
 end

--- a/prototypes/yafc.lua
+++ b/prototypes/yafc.lua
@@ -182,6 +182,95 @@ if mods['pyalienlife'] then
             }
         end
     end
+
+    log('Improve TURD selection')
+
+    ITEM {
+        type = 'item',
+        name = 'hidden-beacon-turd',
+        icon = data.raw['beacon']['hidden-beacon-turd'].icon,
+        icon_size = data.raw['beacon']['hidden-beacon-turd'].icon_size,
+        place_result = 'hidden-beacon-turd'
+    }
+    RECIPE {
+        type = 'recipe',
+        name = 'hidden-beacon-turd',
+        ingredients = {},
+        result = 'hidden-beacon-turd'
+    }
+
+    local tech_upgrades = require('__pyalienlife__/prototypes/upgrades/tech-upgrades')
+    for _, tech_upgrade in pairs(tech_upgrades) do
+        local master_tech = tech_upgrade.master_tech
+        for _, tech in pairs(tech_upgrade.sub_techs) do
+            local effects = {}
+            for _, effect in pairs(tech.effects) do
+                if effect.type == 'module-effects' then
+                    local modules = {}
+                    if data.raw.module[tech.name .. '-module'] then
+                        table.insert(modules, tech.name .. '-module')
+                    else
+                        for i, entity in pairs(tech_upgrade.affected_entities or {}) do
+                            table.insert(modules, tech.name .. '-module-mk0' .. i)
+                        end
+                    end
+                    for _, module in pairs(modules) do
+                        RECIPE {
+                            type = 'recipe',
+                            name = module,
+                            enabled = false,
+                            ingredients = {},
+                            result = module
+                        }
+                        table.insert(effects, {
+                            type = 'unlock-recipe',
+                            recipe = module
+                        })
+                    end
+                elseif effect.type == 'unlock-recipe' then
+                    table.insert(effects, {
+                        type = 'unlock-recipe',
+                        recipe = effect.recipe
+                    })
+                elseif effect.type == 'recipe-replacement' then
+                    table.insert(effects, {
+                        type = 'unlock-recipe',
+                        recipe = effect.new
+                    })
+                end
+            end
+            TECHNOLOGY {
+                type = 'technology',
+                name = 'turd-select-' .. tech.name,
+                localised_name = {'', {'turd.select'}, ' ', {'technology-name.' .. tech.name}},
+                icon = tech.icon,
+                icon_size = tech.icon_size,
+                order = tech.order,
+                prerequisites = {},
+                effects = {},
+                enabled = false,
+                unit = {
+                    count = 1,
+                    ingredients = {},
+                    time = 60
+                }
+            }
+            TECHNOLOGY {
+                type = 'technology',
+                name = tech.name,
+                icon = tech.icon,
+                icon_size = tech.icon_size,
+                order = tech.order,
+                prerequisites = {master_tech.name, 'turd-select-' .. tech.name},
+                effects = effects,
+                unit = {
+                    count = 1,
+                    ingredients = {},
+                    time = 60
+                }
+            }
+        end
+    end
 end
 
 if mods['pyalternativeenergy'] then


### PR DESCRIPTION
This creates sub-technologies for the T.U.R.D. selections including the unlocked recipes and modules. Replacement does not work properly, and probably never will.

This makes the recipes show their unlocking technology
<img width="263" alt="image" src="https://github.com/pyanodon/pypostprocessing/assets/22458042/242d794e-8ba1-4839-a08a-4062292b4735">

There is a separate selection technology that is supposed to be manually marked as accessible in YAFC.
<img width="412" alt="image" src="https://github.com/pyanodon/pypostprocessing/assets/22458042/474f22e7-e84d-47a2-a851-d79533c3d336">

Marking the main technology as accessible would break the reachability analysis and make the recipes (and to some extent their products) available without access to any science packs.

IMPORTANT: This change only works in combination with returning the tech_upgrades table in __pyalienlife__/prototypes/upgrades/tech-upgrades.lua