### PR TITLE
PyPP now makes all tech use the heterogenous pack cost for higher techs.

### DIFF
--- a/prototypes/config.lua
+++ b/prototypes/config.lua
@@ -64,6 +64,13 @@ local config = {
         end
         return multiplier
     end,
+    TC_SCIENCE_PACK_COUNTS_PER_LEVEL = {},
+    TC_TECH_INGREDIENTS_PER_LEVEL = {},
+    TC_MIL_SCIENCE_IS_PROGRESSION_PACK = not not mods["pystellarexpedition"],
+    TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL = {},
+
+    SCIENCE_PACKS = {},
+    SCIENCE_PACK_INDEX = {},
 
     NON_PRODDABLE_ITEMS = {
         ['empty-barrel-milk'] = true,
@@ -103,6 +110,48 @@ if mods["pyalternativeenergy"] then
     config.ENTITY_SCRIPT_UNLOCKS["numal-reef-mk04"] = { "numal-reef-mk04" }
 end
 
+if mods.pystellarexpedition then
+    config.SCIENCE_PACKS = {
+        'automation-science-pack',
+        'py-science-pack-1',
+        'logistic-science-pack',
+        'military-science-pack',
+        'py-science-pack-2',
+        'chemical-science-pack',
+        'space-science-pack-2',
+        'py-science-pack-3',
+        'production-science-pack',
+        'py-science-pack-4',
+        'utility-science-pack',
+        'space-science-pack',
+    }
+elseif mods.pyalienlife then
+    config.SCIENCE_PACKS = {
+        'automation-science-pack',
+        'py-science-pack-1',
+        'logistic-science-pack',
+        'py-science-pack-2',
+        'chemical-science-pack',
+        'py-science-pack-3',
+        'production-science-pack',
+        'py-science-pack-4',
+        'utility-science-pack',
+        'space-science-pack',
+    }
+else
+    config.SCIENCE_PACKS = {
+        'automation-science-pack',
+        'logistic-science-pack',
+        'chemical-science-pack',
+        'production-science-pack',
+        'utility-science-pack',
+        'space-science-pack',
+    }
+end
+for i, science_pack in pairs(config.SCIENCE_PACKS) do
+    config.SCIENCE_PACK_INDEX[science_pack] = i
+end
+
 
 -- Research time if the science pack is the highest on the tech
 if mods.pystellarexpedition then
@@ -118,7 +167,7 @@ if mods.pystellarexpedition then
     config.TC_SCIENCE_PACK_TIME["py-science-pack-4"] = 600
     config.TC_SCIENCE_PACK_TIME["utility-science-pack"] = 1200
     config.TC_SCIENCE_PACK_TIME["space-science-pack"] = 1800
-else
+elseif mods.pyalienlife then
     config.TC_SCIENCE_PACK_TIME["automation-science-pack"] = 30
     config.TC_SCIENCE_PACK_TIME["py-science-pack-1"] = 45
     config.TC_SCIENCE_PACK_TIME["logistic-science-pack"] = 60
@@ -130,6 +179,82 @@ else
     config.TC_SCIENCE_PACK_TIME["py-science-pack-4"] = 450
     config.TC_SCIENCE_PACK_TIME["utility-science-pack"] = 600
     config.TC_SCIENCE_PACK_TIME["space-science-pack"] = 1200
+else
+    config.TC_SCIENCE_PACK_TIME["automation-science-pack"] = 30
+    config.TC_SCIENCE_PACK_TIME["logistic-science-pack"] = 60
+    config.TC_SCIENCE_PACK_TIME["military-science-pack"] = 90
+    config.TC_SCIENCE_PACK_TIME["chemical-science-pack"] = 120
+    config.TC_SCIENCE_PACK_TIME["production-science-pack"] = 300
+    config.TC_SCIENCE_PACK_TIME["utility-science-pack"] = 600
+    config.TC_SCIENCE_PACK_TIME["space-science-pack"] = 1200
+end
+
+-- Research cost if the science pack is the highest on the tech
+if mods.pystellarexpedition then
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["automation-science-pack"] = {1}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-1"] = {1,2}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["logistic-science-pack"] = {1,2,3}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["military-science-pack"] = {1,2,3,6}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-2"] = {1,2,3,6,10}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["chemical-science-pack"] = {1,2,3,6,10,20}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["space-science-pack-2"] = {1,2,3,6,10,20,30}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-3"] = {1,2,3,6,10,20,30,60}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["production-science-pack"] = {1,2,3,6,10,20,30,60,100}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-4"] = {1,2,3,6,10,20,30,60,100,200}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["utility-science-pack"] = {1,2,3,6,10,20,30,60,100,200,300}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["space-science-pack"] = {1,2,3,6,10,20,30,60,100,200,300,600}
+elseif mods.pyalienlife then
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["automation-science-pack"] = {1}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-1"] = {1,2}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["logistic-science-pack"] = {1,2,3}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-2"] = {1,2,3,6}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["chemical-science-pack"] = {1,2,3,6,10}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-3"] = {1,2,3,6,10,20}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["production-science-pack"] = {1,2,3,6,10,20,30}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["py-science-pack-4"] = {1,2,3,6,10,20,30,60}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["utility-science-pack"] = {1,2,3,6,10,20,30,60,100}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["space-science-pack"] = {1,2,3,6,10,20,30,60,100,200}
+else
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["automation-science-pack"] = {1}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["logistic-science-pack"] = {1,2}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["chemical-science-pack"] = {1,2,3}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["production-science-pack"] = {1,2,3,6}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["utility-science-pack"] = {1,2,3,6,10}
+    config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL["space-science-pack"] = {1,2,3,6,10,20}
+end
+
+for highest_level_pack, counts_per_level in pairs(config.TC_SCIENCE_PACK_COUNTS_PER_LEVEL) do
+    local pack_count = #counts_per_level
+    local packs = {}
+
+    for level, count in pairs(counts_per_level) do
+        packs[#packs+1] = {config.SCIENCE_PACKS[pack_count - level + 1], count}
+    end
+
+    config.TC_TECH_INGREDIENTS_PER_LEVEL[highest_level_pack] = packs
+end
+
+-- Research cost if the science pack is the highest on the tech
+if mods.pystellarexpedition then
+    -- TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL is not needed, since it's a progression pack now
+elseif mods.pyalienlife then
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["automation-science-pack"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["py-science-pack-1"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["logistic-science-pack"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["py-science-pack-2"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["chemical-science-pack"] = 2
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["py-science-pack-3"] = 3
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["production-science-pack"] = 6
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["py-science-pack-4"] = 10
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["utility-science-pack"] = 20
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["space-science-pack"] = 30
+else
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["automation-science-pack"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["logistic-science-pack"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["chemical-science-pack"] = 1
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["production-science-pack"] = 2
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["utility-science-pack"] = 3
+    config.TC_MIL_SCIENCE_PACK_COUNT_PER_LEVEL["space-science-pack"] = 6
 end
 
 


### PR DESCRIPTION
Later Py techs need more and more of the earlier science packs. For Py1 techs, you already need 2 automation packs, and for space sciences you need 200 packs. This commit makes this pattern be used for all techs, even those from other mods.

The pack counts are now configured explicitly instead of via a formula. There's only a few tech packs, so an explicit listing is much easier to tweak than a formula.

Packs that have logi and military science will now be slightly cheaper, because the new system does not consider military science part of the science pack progression.