### PR TITLE
PyPP can now be run without any other Py mods

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,5 +1,5 @@
 local py_utils = require("prototypes.functions.utils")
-
+require('__stdlib__/stdlib/data/data').Util.create_data_globals()
 
 local function set_underground_recipe(underground, belt, prev_underground, prev_belt)
     local dist = data.raw['underground-belt'][underground].max_distance + 1


### PR DESCRIPTION
data-updates.lua did not call create_data_globals on stdlib, so it failed on the RECIPE usages later in the file.

Note that you still have to enable dev mode because there's no cache for only PyPP.