### PR TITLE
PyPP now allows mods to register their own cache file.

### DIFF
--- a/cached-configs/run.lua
+++ b/cached-configs/run.lua
@@ -47,6 +47,11 @@ local function run_cache_files(subset)
 	require(subset)
 end
 
+if pypp_cache_file_to_use ~= nil then
+	pypp_cache_file_to_use()
+	return
+end
+
 -- simple py
 run_cache_files{'pycoalprocessing'}
 run_cache_files{'pyindustry'}

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 0.2.14
 Date: ???
   Changes:
     - Added support for ignore_in_pypp, which avoids the soot recipes breaking the tech tree.
+    - Added support for decentralised cache files, allowing mods to use their own cache file.
 ---------------------------------------------------------------------------------------------------
 Version: 0.2.13
 Date: 2023-9-16


### PR DESCRIPTION
The current cache files are still there, but mods can override it.