### PR TITLE
fix for cargo-ships over sea energy distribution

### DIFF
--- a/prototypes/functions/compatibility.lua
+++ b/prototypes/functions/compatibility.lua
@@ -499,6 +499,9 @@ if mods['cargo-ships'] then
     TECHNOLOGY('water_transport'):remove_prereq('logistics-2'):remove_pack('logistic-science-pack')
     TECHNOLOGY('cargo_ships'):remove_pack('logistic-science-pack')
     TECHNOLOGY('automated_water_transport'):remove_pack('logistic-science-pack')
+    if mods['pyalternativeenergy'] then
+        TECHNOLOGY('oversea-energy-distribution'):remove_prereq('electric-energy-distribution-1'):add_prereq('electric-energy-distribution-2')
+    end
 end
 
 if mods['RenaiTransportation'] then


### PR DESCRIPTION
Found an annoyance that cargo ships oversea energy distribution is able to be researched BEFORE electric-energy-distribution-2, as the big electric pole was moved to that tech.