### PR TITLE
Provide extra information YAFC now requires.

### DIFF
--- a/prototypes/yafc.lua
+++ b/prototypes/yafc.lua
@@ -46,7 +46,7 @@ if mods["pyalienlife"] then
         }
         resource.minable.required_fluid = fluid_name
         resource.minable.fluid_amount = 10
-        resource.autoplace = {}
+        resource.autoplace = { control = "trees" }
 
         for _, recipe_data in ipairs(farm.recipes) do
             local recipe = RECIPE(recipe_data.recipe_name)


### PR DESCRIPTION
I just made [a PR in YAFC](https://github.com/shpaass/yafc-ce/pull/356) that means it now needs to know what surfaces each entity can spawn on. This change provides enough information that YAFC can correctly spawn pY entities. `control`s that give more accurate information about spawning density might be preferable, but YAFC doesn't currently handle that information.