### PR TITLE
Adds a startup setting to enable recipe signals in the signal GUI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 3.0.18
 Date: ?
   Changes:
     - FSM improvements.
+    - Fix crash on load with some minable .results specs
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.17
 Date: 2024-11-20

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Date: ?
   Changes:
     - FSM improvements.
     - Fix crash on load with some minable .results specs
+    - Added a setting to display recipe signals in combinators.
 ---------------------------------------------------------------------------------------------------
 Version: 3.0.17
 Date: 2024-11-20

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -84,21 +84,32 @@ if create_signal_mode then
     for _, alternatives in pairs(signal_recipes) do
         if #alternatives > 1 then
             for _, recipe in pairs(alternatives) do
+                if((recipe.name and string.find(recipe.name, "-canister")) or (recipe.subgroup and string.find(recipe.subgroup, "-compost"))) then
+                    break
+                end
                 recipe.show_amount_in_title = false
                 amt = 0
                 for _, result in pairs(recipe.results) do
-                    if result.name and result.amount then
-                        if recipe.main_product and result.name == recipe.main_product then
-                            amt = result.amount
+                    if result.name  then
+                        local is_main_product = recipe.main_product and result.name == recipe.main_product
+                        if is_main_product and result.probability and result.probability < 1 then
+                            amt = result.probability
                             break
+                        elseif is_main_product and result.amount_min and result.amount_max then
+                            amt = (result.amount_min + result.amount_max)/2
+                            break
+                        elseif result.amount then
+                            if is_main_product then
+                                amt = result.amount
+                                break
+                            end
+                            amt = math.max(amt, result.amount)
                         end
-                        amt = math.max(amt, result.amount)
                     end
                 end
                 for i, name in pairs(recipe.localised_name) do
-                    if i > 1 and amt > 1 then
+                    if i > 1 and amt ~= 1 then
                         recipe.localised_name[i] = {"", "(×", tostring(amt), ") ", name}
-                        break -- avoid repeating output display on compost recipes
                     end
                 end
                 recipe.hide_from_signal_gui = false

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -2,11 +2,13 @@
 pypp-verbose-logging=Verbose logging
 pypp-big-inventory-gui=Big inventory GUI
 pypp-compactified-recipe-tooltips=Compactified recipe tooltips
+pypp-extended-recipe-signals=Add recipe signals
 
 [mod-setting-description]
 pypp-verbose-logging=Generates detailed logs for debugging dependency errors
 pypp-big-inventory-gui=Increases the size of the inventory GUI to fit more recipe icons. Works well with "flat" GUI mode.
 pypp-compactified-recipe-tooltips=Makes recipe tooltips take up less screen space by removing redundant information in the "made-in" section. If a recipe is made in multiple tiers of the same machine, only the first machine tier is shown.
+pypp-extended-recipe-signals=Adds recipe signals to combinators to allow for dynamic recipe switching and adds text indicating the main product yield to the name of many recipes. Causes several unnecessary duplicated signals.
 
 [command-help]
 check-technology-consistency=Checks technologies against their prototypes to ensure they aren't improperly hidden or disabled.\nThis should only be used if you're encountering deadlocks from seemingly orphaned technologies.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -22,3 +22,6 @@ yarm-remote-viewer=Character
 
 [recipe-description]
 affected-by-productivity=[font=default-semibold][color=255,230,192]Affected by productivity[/color][/font]
+
+[recipe-name]
+recipe-amount=(__1__ ×) __2__

--- a/prototypes/next-upgrades.lua
+++ b/prototypes/next-upgrades.lua
@@ -28,7 +28,7 @@ local function check_for_valid_minable_properties(entity)
 
     local minable = entity.minable
     if not minable.result and not minable.results then return false end
-    local minable_result = minable.result or minable.results[1].name or minable.results[1][1]
+    local minable_result = minable.result or minable.results[1] and (minable.results[1].name or minable.results[1][1])
     if not minable_result then return false end
     if minable_result ~= entity.name then return false end
 

--- a/settings.lua
+++ b/settings.lua
@@ -36,5 +36,12 @@ data:extend{
         setting_type = "startup",
         default_value = true,
         order = "e",
+    },
+    {
+        type = "bool-setting",
+        name = "pypp-extended-recipe-signals",
+        setting_type = "startup",
+        default_value = false,
+        order = "e",
     }
 }


### PR DESCRIPTION
Basic solution for pyanodon/pybugreports#741.

Due to the clutter it adds to the signal GUI and recipe names, as well as the potential of non-intuitive behavior when recipe signals are used in train stop names, it is implemented as opt-in.