### PR TITLE
Changed order for recipes to be after everything else when "Add recipe signals" option is on

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -395,11 +395,11 @@ if mods["pycoalprocessing"] then
 end
 
 -- Move recipes to the end of the list in signal selection ui
+-- https://github.com/pyanodon/pypostprocessing/pull/67
 if create_signal_mode then
     for _, recipe in pairs(data.raw["recipe"]) do
         if (not recipe.results or not recipe.results[1]) and not recipe.subgroup then
-            -- This only triggers because of "recipe-unknown". All other recipes are required to have a subgroup if they dont have products defined
-            log("WARNING: invalid recipe definition "..recipe.name)
+            log("WARNING: recipe without a subgroup \""..recipe.name.."\"")
             goto continue
         end
         local old_subgroup = recipe.subgroup

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -3,6 +3,7 @@ require "prototypes.quality"
 local dev_mode = settings.startup["pypp-dev-mode"].value
 local create_cache_mode = settings.startup["pypp-create-cache"].value
 local config = require "prototypes.config"
+local defines = require "prototypes.functions.defines"
 
 local signal_recipes = {
 }
@@ -123,6 +124,37 @@ if create_signal_mode then
                         end
                     end
                 end
+                -- Move recipes to the end of the list in signal selection ui
+                local old_subgroup = recipe.subgroup
+                if not old_subgroup then
+                    local product
+                    if recipe.main_product then
+                        product = recipe.main_product
+                    else
+                        product = recipe.results[1].name
+                    end
+                    local types = defines.prototypes.item
+                    types["fluid"] = 0
+                    for ttype, _ in pairs(types) do
+                        if data.raw[ttype] and data.raw[ttype][product] then
+                            old_subgroup = data.raw[ttype][product].subgroup
+                            break
+                        end
+                    end
+                end
+                if data.raw["item-subgroup"][old_subgroup] then
+                    local new_subgroup = "recipes-"..(old_subgroup)
+                    if not data.raw["item-subgroup"][new_subgroup] then
+                        data:extend{{
+                            type = "item-subgroup",
+                            name = new_subgroup,
+                            group = data.raw["item-subgroup"][old_subgroup].group,
+                            order = "zz-"..(data.raw["item-subgroup"][old_subgroup].order or "")
+                        }}
+                    end
+                    recipe.subgroup = new_subgroup
+                end
+
                 recipe.hide_from_signal_gui = false
             end
         end


### PR DESCRIPTION
Before:
![изображение](https://github.com/user-attachments/assets/d2f1869a-1721-4efe-9669-3bbc544f8904)
After:
![изображение](https://github.com/user-attachments/assets/4aa2b4f0-590d-4160-849d-903273e1c669)

Item signals are now easy to find, and recipe signals, which are usually used more rarely, are moved to the bottom. Relative orders of items and recipes are not changed