### PR TITLE
Lock GUI clicks from being triggered by custom-input event

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -1,4 +1,4 @@
-
+require("prototypes.custom-input")
 -- Log all mods & versions, Alien Biomes already does this so we skip if it is active
 if not mods["alien-biomes"] then
     log("MODSET:\n" .. serpent.block(mods, {sortkeys=false}))

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "pypostprocessing",
-    "version": "3.0.36",
+    "version": "3.0.37",
     "factorio_version": "2.0",
     "title": "Pyanodons Post-processing",
     "author": "Pyanodon, Shadowglass, LambdaLemon",

--- a/lib/events.lua
+++ b/lib/events.lua
@@ -1,4 +1,5 @@
 local events = {}
+local GUI_CLICK_LOCK_DURATION = 20 -- ticks
 -- Moved to top for referencing below
 --- Sentinel values for defining groups of events
 py.events = {
@@ -88,7 +89,7 @@ end
 local function set_ignore_click(f)
     return function(event)
         if event.player_index ~= nil then
-            local offset = math.floor(20 * game.speed + 0.5)
+            local offset = math.floor(GUI_CLICK_LOCK_DURATION * game.speed + 0.5)
             if offset ~= 0 then
                 storage.ignored_players[event.player_index] = game.tick + offset
             end

--- a/lib/events.lua
+++ b/lib/events.lua
@@ -1,139 +1,5 @@
 local events = {}
-
----Drop-in replacement for script.on_event however it supports multiple handlers per event. You can also use 'on_built' 'on_destroyed' and 'on_init' as shortcuts for multiple events.
----@param event defines.events|defines.events[]|string
----@param f function
----@diagnostic disable-next-line: duplicate-set-field
-py.on_event = function(event, f)
-    for _, event in pairs(type(event) == "table" and event or {event}) do
-        event = tostring(event)
-        events[event] = events[event] or {}
-        table.insert(events[event], f)
-    end
-end
-
-local function one_function_from_many(functions)
-    local l = #functions
-    if l == 1 then return functions[1] end
-
-    return function(arg)
-        for i = 1, l do
-            functions[i](arg)
-        end
-    end
-end
-
-local finalized = false
-py.finalize_events = function()
-    if finalized then error("Events already finalized") end
-    local i = 0
-    for event, functions in pairs(events) do
-        local f = one_function_from_many(functions)
-        if type(event) == "number" then
-            script.on_nth_tick(event, f)
-        elseif event == py.events.on_init() then
-            script.on_init(f)
-            script.on_configuration_changed(f)
-        else
-            script.on_event(tonumber(event) or event, f)
-        end
-        i = i + 1
-    end
-    finalized = true
-    log("Finalized " .. i .. " events for " .. script.mod_name)
-end
-
-_G.gui_events = {
-    [defines.events.on_gui_click] = {},
-    [defines.events.on_gui_confirmed] = {},
-    [defines.events.on_gui_text_changed] = {},
-    [defines.events.on_gui_checked_state_changed] = {},
-    [defines.events.on_gui_selection_state_changed] = {},
-    [defines.events.on_gui_checked_state_changed] = {},
-    [defines.events.on_gui_elem_changed] = {},
-    [defines.events.on_gui_value_changed] = {},
-    [defines.events.on_gui_location_changed] = {},
-    [defines.events.on_gui_selected_tab_changed] = {},
-    [defines.events.on_gui_switch_state_changed] = {}
-}
-local function process_gui_event(event)
-    if event.element and event.element.valid then
-        for pattern, f in pairs(gui_events[event.name]) do
-            if event.element.name:match(pattern) then
-                f(event); return
-            end
-        end
-    end
-end
-
-for event, _ in pairs(gui_events) do
-    py.on_event(event, process_gui_event)
-end
-
----@type table<integer, table<int, {name: string, params: any[]?}>>
-storage.on_tick = storage.on_tick or {}
----@type table<string, function>
-py.on_tick_funcs = {}
-
----register delayed functions
----@param func_name string
----@param func function
-py.register_delayed_function = function(func_name, func)
-    log("registered delayed_event function " .. func_name)
-    if py.on_tick_funcs[func_name] and py.on_tick_funcs[func_name] ~= func then error("attempting to overwrite a registered function " .. func_name) end
-    py.on_tick_funcs[func_name] = func
-end
-
--- use this to call functions after a delay
--- pass parameters in a list
----@param delay uint
----@param func_name string
----@param params any[]?
-py.delayed_event = function(delay, func_name, params)
-    if delay < 0 then
-        error("invalid event delay with function " .. func_name)
-        return
-    end
-    params = params or {}
-    if type(params) ~= "table" then params = {params} end
-    local tick = game.tick + delay
-    storage.on_tick[tick] = storage.on_tick[tick] or {}
-    table.insert(storage.on_tick[tick], {name = func_name, params = params})
-end
-
-local on_nth_tick_init = false
-local function_list = {}
-
-py.mod_nth_tick_funcs = {}
-
----use instead of script.on_nth_tick, avoids multiple functions running on the same tick
----@param tick int
----@param func_name string
----@param mod string
----@param func function
-py.register_on_nth_tick = function(tick, func_name, mod, func)
-    if py.mod_nth_tick_funcs[mod .. "-" .. func_name] then error("py.register_on_nth_tick: function with name " .. mod .. "-" .. func_name .. " is already registered") end
-    function_list[func_name] = {tick = tick, mod = mod}
-    py.mod_nth_tick_funcs[mod .. "-" .. func_name] = func
-end
-
-py.on_event(defines.events.on_tick, function(event)
-    -- on_nth_tick
-    if not on_nth_tick_init then
-        remote.call("on_nth_tick", "add", function_list)
-        on_nth_tick_init = true
-    end
-
-    -- delayed funcs
-    local tick = event.tick
-    if not (storage.on_tick and storage.on_tick[tick]) then return end
-    for _, func_details in pairs(storage.on_tick[tick]) do
-        local success, err = pcall(py.on_tick_funcs[func_details.name], table.unpack(func_details.params))
-        if not success then error("error in on tick function " .. func_details.name .. ": " .. err) end
-    end
-    storage.on_tick[tick] = nil
-end)
-
+-- Moved to top for referencing below
 --- Sentinel values for defining groups of events
 py.events = {
     --- Called after an entity is constructed.
@@ -203,3 +69,185 @@ py.events = {
         return "open-gui"
     end
 }
+
+
+
+---Workaround for the "open-gui" custom input also triggering clicks on the GUI that is opened
+local ignored_players = {}
+---Conditionally runs the given event based on if the player is not present within ignored_players
+---@param event EventData.on_gui_click
+---@param f function event handler
+local function wrapped_click(event, f)
+    log(serpent.block(event))
+    -- Runs if the click wasn't caused by a custom-input click
+    local player_index = event and event.player_index ~= nil or -1
+    if ignored_players[player_index] then
+        log("[" .. game.tick .. "] forget")
+        ignored_players[player_index] = nil
+        return
+    end
+    f(event)
+end
+---Sets event's player_index into ignored_players before running the given function
+---@param f function event handler
+---@return function function wrapped event handler
+local function set_ignore_click(f)
+    return function(event)
+        if event.player_index ~= nil then
+            log("[" .. game.tick .. "] set")
+            ignored_players[event.player_index] = true
+        end
+        f(event)
+    end
+end
+
+
+---Drop-in replacement for script.on_event however it supports multiple handlers per event. You can also use 'on_built' 'on_destroyed' and 'on_init' as shortcuts for multiple events.
+---@param event defines.events|defines.events[]|string
+---@param f function
+---@diagnostic disable-next-line: duplicate-set-field
+py.on_event = function(event, f)
+    for _, event in pairs(type(event) == "table" and event or {event}) do
+        event = tostring(event)
+        events[event] = events[event] or {}
+        -- Handle the GUI click wrapping
+        if event == py.events.on_entity_clicked() then
+            f = set_ignore_click(f)
+        end
+        table.insert(events[event], f)
+    end
+end
+
+local function one_function_from_many(functions)
+    local l = #functions
+    if l == 1 then return functions[1] end
+
+    return function(arg)
+        for i = 1, l do
+            functions[i](arg)
+        end
+    end
+end
+
+local finalized = false
+py.finalize_events = function()
+    if finalized then error("Events already finalized") end
+    local i = 0
+    for event, functions in pairs(events) do
+        local f = one_function_from_many(functions)
+        if type(event) == "number" then
+            script.on_nth_tick(event, f)
+        elseif event == py.events.on_init() then
+            script.on_init(f)
+            script.on_configuration_changed(f)
+        else
+            script.on_event(tonumber(event) or event, f)
+        end
+        i = i + 1
+    end
+    finalized = true
+    log("Finalized " .. i .. " events for " .. script.mod_name)
+end
+
+_G.gui_events = {
+    [defines.events.on_gui_click] = {},
+    [defines.events.on_gui_confirmed] = {},
+    [defines.events.on_gui_text_changed] = {},
+    [defines.events.on_gui_checked_state_changed] = {},
+    [defines.events.on_gui_selection_state_changed] = {},
+    [defines.events.on_gui_checked_state_changed] = {},
+    [defines.events.on_gui_elem_changed] = {},
+    [defines.events.on_gui_value_changed] = {},
+    [defines.events.on_gui_location_changed] = {},
+    [defines.events.on_gui_selected_tab_changed] = {},
+    [defines.events.on_gui_switch_state_changed] = {}
+}
+local function process_gui_event(event)
+    if event.element and event.element.valid then
+        local is_click = event.name == defines.events.on_gui_click
+        if is_click then
+            log("[" .. game.tick .. "] click")
+        end
+        for pattern, f in pairs(gui_events[event.name]) do
+            if event.element.name:match(pattern) then
+                log(event.name)
+                _ = is_click and wrapped_click(event, f) or f(event)
+                return
+            end
+        end
+    end
+end
+
+for event, _ in pairs(gui_events) do
+    py.on_event(event, process_gui_event)
+end
+
+---@type table<integer, table<int, {name: string, params: any[]?}>>
+storage.on_tick = storage.on_tick or {}
+---@type table<string, function>
+py.on_tick_funcs = {}
+
+---register delayed functions
+---@param func_name string
+---@param func function
+py.register_delayed_function = function(func_name, func)
+    log("registered delayed_event function " .. func_name)
+    if py.on_tick_funcs[func_name] and py.on_tick_funcs[func_name] ~= func then error("attempting to overwrite a registered function " .. func_name) end
+    py.on_tick_funcs[func_name] = func
+end
+
+-- use this to call functions after a delay
+-- pass parameters in a list
+---@param delay uint
+---@param func_name string
+---@param params any[]?
+py.delayed_event = function(delay, func_name, params)
+    if delay < 0 then
+        error("invalid event delay with function " .. func_name)
+        return
+    end
+    params = params or {}
+    if type(params) ~= "table" then params = {params} end
+    local tick = game.tick + delay
+    storage.on_tick[tick] = storage.on_tick[tick] or {}
+    table.insert(storage.on_tick[tick], {name = func_name, params = params})
+end
+
+local on_nth_tick_init = false
+local function_list = {}
+
+py.mod_nth_tick_funcs = {}
+
+---use instead of script.on_nth_tick, avoids multiple functions running on the same tick
+---@param tick int
+---@param func_name string
+---@param mod string
+---@param func function
+py.register_on_nth_tick = function(tick, func_name, mod, func)
+    if py.mod_nth_tick_funcs[mod .. "-" .. func_name] then error("py.register_on_nth_tick: function with name " .. mod .. "-" .. func_name .. " is already registered") end
+    function_list[func_name] = {tick = tick, mod = mod}
+    py.mod_nth_tick_funcs[mod .. "-" .. func_name] = func
+end
+
+py.on_event(defines.events.on_tick, function(event)
+    -- on_nth_tick
+    if not on_nth_tick_init then
+        remote.call("on_nth_tick", "add", function_list)
+        on_nth_tick_init = true
+    end
+
+    -- gui handler
+    if next(ignored_players) ~= nil then
+        --log("[" .. game.tick .. "] all")
+    end
+    --ignored_players = {}
+
+    -- delayed funcs
+    local tick = event.tick
+    if not (storage.on_tick and storage.on_tick[tick]) then return end
+    for _, func_details in pairs(storage.on_tick[tick]) do
+        local success, err = pcall(py.on_tick_funcs[func_details.name], table.unpack(func_details.params))
+        if not success then error("error in on tick function " .. func_details.name .. ": " .. err) end
+    end
+    storage.on_tick[tick] = nil
+end)

--- a/prototypes/custom-input.lua
+++ b/prototypes/custom-input.lua
@@ -1,0 +1,7 @@
+data:extend {{
+    type = "custom-input",
+    name = "open-gui",
+    key_sequence = "",
+    linked_game_control = "open-gui",
+    include_selected_prototype = true
+}}


### PR DESCRIPTION
Custom input triggers on GUI down, which can open a GUI, and then GUI click triggers on mouse up. This is bad.

Workaround is not firing GUI click events for a short period after the custom input.