### PR TITLE
bump version for next release, move changelog to appropriate version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 3.0.39
+Date: ???
+  Changes:
+    - Cars, tanks, and spidertrons are no longer remote-drivable if they have the "hidden" flag.
+---------------------------------------------------------------------------------------------------
 Version: 3.0.38
 Date: 2025-08-23
   Changes:
-    - Cars, tanks, and spidertrons are no longer remote-drivable if they have the "hidden" flag.
     - Fixed crash when placing a building while paused at 0 ticks elapsed.
     - Added an opt-in setting to find undocumented global variables. It will print warnings for now, in the future it will always be on and crash the game so testing and reporting is appreciated!
 ---------------------------------------------------------------------------------------------------

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "pypostprocessing",
-    "version": "3.0.38",
+    "version": "3.0.39",
     "factorio_version": "2.0",
     "title": "Pyanodons Post-processing",
     "author": "Pyanodon, Shadowglass, LambdaLemon",


### PR DESCRIPTION
alpha testers need this so the portal doesn't pull down the version without ends_with