### PR TITLE
Allow AdminUnknownFixes for Angel's + Py

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 3.0.42
 Date: ???
   Changes:
+    - Allow AdminUnknownFixes to satisfy the Angel's + Py / PyCoalTBaA compatibility gate
     - Fix load failure with zh-cn locale. Resolves https://github.com/pyanodon/pybugreports/issues/1347
     - Added py.spoilage_enabled() which checks for the feature flag and mod setting
     - Added META:hide() and META:unhide() to hide/unhide the prototype from any in-game browser and factoriopedia

--- a/prototypes/functions/compatibility.lua
+++ b/prototypes/functions/compatibility.lua
@@ -15,7 +15,7 @@ then
     end
 end
 
-if mods["angelsrefining"] and not mods["PyCoalTBaA"] then
+if mods["angelsrefining"] and not mods["PyCoalTBaA"] and not mods["AdminUnknownFixes"] then
     error("\n\n\n\n\nPlease install PyCoal Touched By an Angel\n\n\n\n\n")
 end
 


### PR DESCRIPTION
**Context:** [AdminUnknownFixes](https://github.com/jakegodding/AdminUnknownFixes) merges former PyCoalTBaA / PyPPTBaA (`pyppatba`) bridge work for Factorio 2.0 + Angel's + Py.

**Change A:** Skip the ``Please install PyCoal Touched By an Angel`` `error()` when `mods[AdminUnknownFixes]` is set (see `prototypes/functions/compatibility.lua`).

**Rationale:** Legacy [PyCoalTBaA](https://mods.factorio.com/mod/PyCoalTBaA) is 1.1-era; the Angel's + Py bridge for 2.0 lives in AdminUnknownFixes. Players with AdminUnknownFixes should not need an empty PyCoalTBaA stub.

**Safety:** If the real PyCoalTBaA mod is enabled, `mods[PyCoalTBaA]` is true and the error path is unchanged.

**Reference:** [Upstream PR checklist](https://github.com/Admin-Unknown/AdminUnknownFixes/blob/main/docs/pypostprocessing-upstream-pr.md)

Made with [Cursor](https://cursor.com)